### PR TITLE
Lillian & Sydney - Print Icon to CSV, Delete Item Button

### DIFF
--- a/frontend/src/components/Admin/Inventory/Forms/View-Form.tsx
+++ b/frontend/src/components/Admin/Inventory/Forms/View-Form.tsx
@@ -9,7 +9,7 @@ import SelectField, { SelectOption } from "@/components/ui/selectField";
 import ItemImageUpload from "@/components/Admin/Inventory/Upload-Image/ItemImageUpload";
 import SetCoverPhotoModal from "@/components/Admin/Inventory/SetCoverPhotoModal";
 import SaleModal from "@/components/Admin/Inventory/Forms/Add-Sale";
-import { Trash } from "lucide-react";
+import { Trash, Printer } from "lucide-react";
 
 // OPTIONS
 
@@ -43,56 +43,11 @@ const COLOR_OPTIONS: SelectOption[] = [
 ];
 
 const STATE_OPTIONS: SelectOption[] = [
-  "AL",
-  "AK",
-  "AZ",
-  "AR",
-  "CA",
-  "CO",
-  "CT",
-  "DE",
-  "FL",
-  "GA",
-  "HI",
-  "ID",
-  "IL",
-  "IN",
-  "IA",
-  "KS",
-  "KY",
-  "LA",
-  "ME",
-  "MD",
-  "MA",
-  "MI",
-  "MN",
-  "MS",
-  "MO",
-  "MT",
-  "NE",
-  "NV",
-  "NH",
-  "NJ",
-  "NM",
-  "NY",
-  "NC",
-  "ND",
-  "OH",
-  "OK",
-  "OR",
-  "PA",
-  "RI",
-  "SC",
-  "SD",
-  "TN",
-  "TX",
-  "UT",
-  "VT",
-  "VA",
-  "WA",
-  "WV",
-  "WI",
-  "WY",
+  "AL","AK","AZ","AR","CA","CO","CT","DE","FL","GA",
+  "HI","ID","IL","IN","IA","KS","KY","LA","ME","MD",
+  "MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ",
+  "NM","NY","NC","ND","OH","OK","OR","PA","RI","SC",
+  "SD","TN","TX","UT","VT","VA","WA","WV","WI","WY",
 ].map((s) => ({ label: s, value: s }));
 
 // FIELD WRAPPER
@@ -123,9 +78,7 @@ export default function ViewForm() {
   const [saving, setSaving] = useState(false);
   const [showCoverModal, setShowCoverModal] = useState(false);
   const [showSaleModal, setShowSaleModal] = useState(false);
-  const [toast, setToast] = useState<{ message: string; sub: string } | null>(
-    null,
-  );
+  const [toast, setToast] = useState<{ message: string; sub: string } | null>(null);
 
   const { id: itemId } = useParams<{ id: string }>();
   const router = useRouter();
@@ -154,6 +107,33 @@ export default function ViewForm() {
     setTimeout(() => setToast(null), 6000);
   };
 
+  const handleGenerateLabel = () => {
+    const rows = [
+      ["SKU", "Breed", "Grade", "Farmer Name", "QR Code"],
+      [
+        formData.sku ?? "",
+        formData.breed ?? "",
+        formData.grade ?? "",
+        formData.farmerName ?? "",
+        formData.qrCode ?? "",
+      ],
+    ];
+
+    const csv = rows
+      .map((row) =>
+        row.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(",")
+      )
+      .join("\n");
+
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `label-${formData.sku ?? itemId}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   const handlePublish = async () => {
     try {
       if (formData?.isPublic == false) {
@@ -161,7 +141,7 @@ export default function ViewForm() {
         setFormData((p) => ({ ...p, isPublic: true }));
         showToast(
           "Lot successfully published!",
-          "Your changes have been saved and published externally. Change the status to ”Processing” to hide this lot from the public inventory.",
+          "Your changes have been saved and published externally. Change the status to \"Processing\" to hide this lot from the public inventory.",
         );
       } else {
         await updateItem(itemId, { isPublic: false });
@@ -186,7 +166,7 @@ export default function ViewForm() {
       });
       showToast(
         "Lot successfully updated!",
-        "Your changes have been saved internally. Change the status to “In Stock” to make this lot available for sale.",
+        "Your changes have been saved internally. Change the status to \"In Stock\" to make this lot available for sale.",
       );
     } catch {
       setError("Failed to save.");
@@ -197,9 +177,7 @@ export default function ViewForm() {
 
   const handleDelete = async () => {
     if (
-      !confirm(
-        "Are you sure you want to delete this lot? This action cannot be undone.",
-      )
+      !confirm("Are you sure you want to delete this lot? This action cannot be undone.")
     ) {
       return;
     }
@@ -228,8 +206,12 @@ export default function ViewForm() {
           ← Back to Inventory
         </Link>
         <div className="hidden md:flex gap-2">
-          <button className="rounded border border-gray-300 px-4 py-1.5 text-sm hover:bg-gray-50">
-            Print Label
+          <button
+            onClick={handleGenerateLabel}
+            className="hover:bg-gray-50 rounded p-1"
+            aria-label="Print Label"
+          >
+            <Printer size={24} />
           </button>
           <button onClick={handleDelete}>
             <Trash size={24} />
@@ -255,6 +237,7 @@ export default function ViewForm() {
           </button>
         </div>
       </div>
+
       {/* SKU */}
       <div className="mb-6 hidden md:block">
         <p className="text-base font-semibold text-gray-900">
@@ -264,53 +247,27 @@ export default function ViewForm() {
       <h1 className="text-lg font-bold mb-4 md:hidden">
         SKU: {formData.sku ?? itemId}
       </h1>
+
       <div className="grid grid-cols-1 md:grid-cols-[1fr_380px] gap-6 md:gap-12 items-start">
         {/* LEFT */}
         <div className="flex flex-col gap-6 md:gap-10">
           <section>
-            <h2 className="text-xl font-bold mb-4 md:mb-5">
-              General Information
-            </h2>
+            <h2 className="text-xl font-bold mb-4 md:mb-5">General Information</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4 md:gap-y-5">
               <Field label="Breed">
-                <EditableField
-                  isEditing
-                  value={formData.breed ?? ""}
-                  placeholder="Breed"
-                  onChange={set("breed")}
-                />
+                <EditableField isEditing value={formData.breed ?? ""} placeholder="Breed" onChange={set("breed")} />
               </Field>
               <Field label="Grade">
-                <SelectField
-                  value={formData.grade ?? ""}
-                  onChange={set("grade")}
-                  options={GRADE_OPTIONS}
-                  placeholder="Grade"
-                />
+                <SelectField value={formData.grade ?? ""} onChange={set("grade")} options={GRADE_OPTIONS} placeholder="Grade" />
               </Field>
               <Field label="Color">
-                <SelectField
-                  value={formData.color ?? ""}
-                  onChange={set("color")}
-                  options={COLOR_OPTIONS}
-                  placeholder="Color"
-                />
+                <SelectField value={formData.color ?? ""} onChange={set("color")} options={COLOR_OPTIONS} placeholder="Color" />
               </Field>
               <Field label="Quantity (lb)">
-                <EditableField
-                  isEditing
-                  value={String(formData.weight ?? "")}
-                  placeholder="Weight"
-                  onChange={set("weight")}
-                />
+                <EditableField isEditing value={String(formData.weight ?? "")} placeholder="Weight" onChange={set("weight")} />
               </Field>
               <Field label="Status">
-                <SelectField
-                  value={formData.status ?? ""}
-                  onChange={set("status")}
-                  options={STATUS_OPTIONS}
-                  placeholder="Status"
-                />
+                <SelectField value={formData.status ?? ""} onChange={set("status")} options={STATUS_OPTIONS} placeholder="Status" />
               </Field>
               <Field label="Type">
                 <SelectField
@@ -321,59 +278,28 @@ export default function ViewForm() {
                 />
               </Field>
               <Field label="Pallet Location">
-                <EditableField
-                  isEditing
-                  value={formData.palletLocation ?? ""}
-                  placeholder="Pallet Number"
-                  onChange={set("palletLocation")}
-                />
+                <EditableField isEditing value={formData.palletLocation ?? ""} placeholder="Pallet Number" onChange={set("palletLocation")} />
               </Field>
             </div>
           </section>
 
           <section>
-            <h2 className="text-xl font-bold mb-4 md:mb-5">
-              Purchase Information
-            </h2>
+            <h2 className="text-xl font-bold mb-4 md:mb-5">Purchase Information</h2>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-4 md:gap-y-5">
               <Field label="Farmer Name">
-                <EditableField
-                  isEditing={false}
-                  value={formData.farmerName ?? ""}
-                  placeholder="Name"
-                />
+                <EditableField isEditing={false} value={formData.farmerName ?? ""} placeholder="Name" />
               </Field>
               <Field label="Shear Date">
-                <EditableField
-                  isEditing
-                  value={formData.shearDate ?? ""}
-                  placeholder="MM/DD/YYYY"
-                  onChange={set("shearDate")}
-                />
+                <EditableField isEditing value={formData.shearDate ?? ""} placeholder="MM/DD/YYYY" onChange={set("shearDate")} />
               </Field>
               <Field label="Farmer City">
-                <EditableField
-                  isEditing={false}
-                  value={formData.farmerCity ?? ""}
-                  placeholder="City"
-                />
+                <EditableField isEditing={false} value={formData.farmerCity ?? ""} placeholder="City" />
               </Field>
               <Field label="Farmer State">
-                <SelectField
-                  value={formData.farmerState ?? ""}
-                  onChange={() => {}}
-                  options={STATE_OPTIONS}
-                  placeholder="State"
-                  disabled
-                />
+                <SelectField value={formData.farmerState ?? ""} onChange={() => {}} options={STATE_OPTIONS} placeholder="State" disabled />
               </Field>
               <Field label="Intake Price ($/lb)">
-                <EditableField
-                  isEditing
-                  value={String(formData.purchasePrice ?? "")}
-                  placeholder="Price"
-                  onChange={set("purchasePrice")}
-                />
+                <EditableField isEditing value={String(formData.purchasePrice ?? "")} placeholder="Price" onChange={set("purchasePrice")} />
               </Field>
             </div>
           </section>
@@ -381,13 +307,8 @@ export default function ViewForm() {
 
         {/* RIGHT */}
         <div className="flex flex-col gap-4">
-          <ItemImageUpload
-            sku={item.sku}
-            existingImages={images}
-            onImagesChange={setImages}
-          />
+          <ItemImageUpload sku={item.sku} existingImages={images} onImagesChange={setImages} />
 
-          {/* Set cover photo — only shown when images exist */}
           {images.length > 0 && (
             <button
               type="button"
@@ -399,33 +320,21 @@ export default function ViewForm() {
           )}
 
           <Field label="Notes">
-            <EditableField
-              isEditing
-              value={formData.notes ?? ""}
-              placeholder="Notes"
-              multiline
-              onChange={set("notes")}
-            />
+            <EditableField isEditing value={formData.notes ?? ""} placeholder="Notes" multiline onChange={set("notes")} />
           </Field>
 
           {/* Mobile save/publish buttons */}
           <div className="flex flex-col gap-3 md:hidden">
-            <button
-              onClick={handlePublish}
-              className="w-full rounded px-4 py-2.5 text-sm text-white bg-gray-900 hover:bg-gray-700"
-            >
+            <button onClick={handlePublish} className="w-full rounded px-4 py-2.5 text-sm text-white bg-gray-900 hover:bg-gray-700">
               {formData.isPublic ? "Unpublish" : "Publish"}
             </button>
-            <button
-              onClick={handleSave}
-              disabled={saving}
-              className="w-full rounded border px-4 py-2.5 text-sm text-white bg-[#2C2C2C] hover:bg-[#1A1A1A] disabled:opacity-50"
-            >
+            <button onClick={handleSave} disabled={saving} className="w-full rounded border px-4 py-2.5 text-sm text-white bg-[#2C2C2C] hover:bg-[#1A1A1A] disabled:opacity-50">
               {saving ? "Saving..." : "Save Changes"}
             </button>
           </div>
         </div>
       </div>
+
       {/* Set Cover Photo Modal */}
       {showCoverModal && (
         <SetCoverPhotoModal
@@ -433,11 +342,10 @@ export default function ViewForm() {
           images={images}
           currentCover={formData.coverImage ?? images[0] ?? ""}
           onClose={() => setShowCoverModal(false)}
-          onSave={(newCover) =>
-            setFormData((p) => ({ ...p, coverImage: newCover }))
-          }
+          onSave={(newCover) => setFormData((p) => ({ ...p, coverImage: newCover }))}
         />
       )}
+
       {showSaleModal && (
         <SaleModal
           itemId={itemId}
@@ -445,21 +353,17 @@ export default function ViewForm() {
           onClose={() => setShowSaleModal(false)}
           onSaleRecorded={(id, total) => console.log("Sold!", id, total)}
         />
-      )}{" "}
+      )}
+
       {/* Toast Notification */}
       {toast && (
         <div className="fixed bottom-6 right-6 z-50 w-80 rounded-lg border border-gray-200 bg-white p-4 shadow-lg">
           <div className="flex items-start justify-between gap-2">
             <div>
-              <p className="font-semibold text-gray-900 text-sm">
-                {toast.message}
-              </p>
+              <p className="font-semibold text-gray-900 text-sm">{toast.message}</p>
               <p className="mt-1 text-sm text-gray-600">{toast.sub}</p>
             </div>
-            <button
-              onClick={() => setToast(null)}
-              className="text-gray-400 hover:text-gray-600 mt-0.5 shrink-0"
-            >
+            <button onClick={() => setToast(null)} className="text-gray-400 hover:text-gray-600 mt-0.5 shrink-0">
               ✕
             </button>
           </div>

--- a/frontend/src/components/Admin/Inventory/Forms/View-Form.tsx
+++ b/frontend/src/components/Admin/Inventory/Forms/View-Form.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
-import { getItemById, updateItem, Item } from "@/api/items";
+import { getItemById, updateItem, deleteItem, Item } from "@/api/items";
 import EditableField from "@/components/ui/EditableField";
 import SelectField, { SelectOption } from "@/components/ui/selectField";
 import ItemImageUpload from "@/components/Admin/Inventory/Upload-Image/ItemImageUpload";
 import SetCoverPhotoModal from "@/components/Admin/Inventory/SetCoverPhotoModal";
 import SaleModal from "@/components/Admin/Inventory/Forms/Add-Sale";
+import { Trash } from "lucide-react";
 
 // OPTIONS
 
@@ -127,6 +128,7 @@ export default function ViewForm() {
   );
 
   const { id: itemId } = useParams<{ id: string }>();
+  const router = useRouter();
 
   useEffect(() => {
     const fetchItem = async () => {
@@ -193,6 +195,22 @@ export default function ViewForm() {
     }
   };
 
+  const handleDelete = async () => {
+    if (
+      !confirm(
+        "Are you sure you want to delete this lot? This action cannot be undone.",
+      )
+    ) {
+      return;
+    }
+    try {
+      await deleteItem(itemId);
+      router.push("/inventory");
+    } catch {
+      setError("Failed to delete.");
+    }
+  };
+
   if (loading) return <div className="p-4 md:p-8">Loading...</div>;
   if (!item)
     return (
@@ -212,6 +230,9 @@ export default function ViewForm() {
         <div className="hidden md:flex gap-2">
           <button className="rounded border border-gray-300 px-4 py-1.5 text-sm hover:bg-gray-50">
             Print Label
+          </button>
+          <button onClick={handleDelete}>
+            <Trash size={24} />
           </button>
           <button
             onClick={() => setShowSaleModal(true)}


### PR DESCRIPTION
## Changes

### Task 1: Delete Item (Lillian)
- Added a `handleDelete` function in `View-Form.tsx` that calls the existing `deleteItem` endpoint from `api/items.ts`
- Shows a confirmation dialog before deletion to prevent accidental data loss
- Redirects to `/inventory` after successful deletion
- Wired up to a `<Trash>` icon button (lucide-react) in the header, matching the Figma design

### Task 2: Print Label (CSV Export) (Sydney)
- Added a `handleGenerateLabel` function in `View-Form.tsx` that builds and downloads a CSV file containing: SKU, Breed, Grade, Farmer Name, and QR Code
- CSV values are quoted and escaped to handle commas or special characters in field values
- Downloaded file is named `label-<SKU>.csv`
- Wired up to a `<Printer>` icon button (lucide-react) in the header, matching the Figma design

### Changes Made to Last Ticket (this was implemented before this ticket but I felt like I had to include this somewhere even though it was already part of master when we pulled lol)
- Replaced the compound SKU format (`STATE-GRADE-COLOR-BREED-###`) with a simple auto-incrementing integer (`0001`, `0002`, ...)
- Uses a Firestore transaction on a `counters/items` document to ensure uniqueness under concurrent requests

### Testing

### Delete
- [ ] Click the trash icon on an existing item --> confirm dialog appears
- [ ] Click Cancel in the dialog --> item is NOT deleted, stays on the page
- [ ] Click OK —--> item is deleted and you are redirected to `/inventory`
- [ ] Confirm the deleted item no longer appears in the inventory list
- [ ] Try navigating directly to the deleted item's URL --> should return a not-found state, not crash
<img width="666" height="228" alt="image" src="https://github.com/user-attachments/assets/85afc94f-e0bf-414d-ae09-c7459f2ef9c6" />


### Print Label / CSV
- [ ] Clicked the printer icon --> a CSV file downloads automatically
- [ ] Opened the CSV and verify all 5 columns are present: SKU, Breed, Grade, Farmer Name, QR Code
- [ ] Verified the values match what is shown on the item's form
- [ ] Tested with a farmer name or breed that contains a comma -->  confirm it is correctly quoted in the CSV and doesn't break the column structure
- [ ] File should be named `label-<SKU>.csv`
<img width="735" height="151" alt="image" src="https://github.com/user-attachments/assets/acdd80dd-f377-4a53-9b19-44bc405d64b8" />
