### PR TITLE
completed tasks 1 and 2

### DIFF
--- a/backend/src/controllers/sales.ts
+++ b/backend/src/controllers/sales.ts
@@ -66,7 +66,7 @@ export const addSale = async (
       body.pricePerWeight === undefined ||
       body.costPerWeight === undefined ||
       !body.soldAt ||
-      !body.notes
+      !body.buyerName
     ) {
       return res.status(400).json(errorJson("Missing required fields"));
     }

--- a/backend/src/models/sales.ts
+++ b/backend/src/models/sales.ts
@@ -9,7 +9,10 @@ export interface SaleFields {
   costPerWeight: number;
   soldAt: Timestamp;
   buyerName: string;
-  notes: string 
+  buyerPhone?: string;
+  buyerEmail?: string;
+  buyerAddress?: string;
+  notes: string;
 }
 
 export type SaleInsert = SaleFields;

--- a/frontend/src/api/sales.ts
+++ b/frontend/src/api/sales.ts
@@ -8,11 +8,14 @@ export type Sale = {
   totalPrice: number;
   costPerWeight: number;
   soldAt: string;
-  buyerName?: string;
+  buyerName: string;       
+  buyerPhone?: string;    
+  buyerEmail?: string;     
+  buyerAddress?: string; 
   notes: string;
 };
 
-export type SaleInput = Omit<Sale, "id" | "totalPrice">;
+export type SaleInput = Omit<Sale, "id">;
 
 export const getAllSales = async () => {
   return apiRequest<Sale[]>("/api/getAllSales", { method: "GET" });

--- a/frontend/src/components/Admin/Inventory/Forms/Add-Sale.tsx
+++ b/frontend/src/components/Admin/Inventory/Forms/Add-Sale.tsx
@@ -20,6 +20,10 @@ export default function SaleModal({
   const [weightSold, setWeightSold] = useState("");
   const [pricePerWeight, setPricePerWeight] = useState("");
   const [notes, setNotes] = useState("");
+  const [buyerName, setBuyerName] = useState("");
+  const [buyerPhone, setBuyerPhone] = useState("");
+  const [buyerEmail, setBuyerEmail] = useState("");
+  const [buyerAddress, setBuyerAddress] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -81,23 +85,27 @@ export default function SaleModal({
       : null;
 
   const handleSubmit = async () => {
-    if (!weightSold || !pricePerWeight) {
-      setError("Quantity and price are required.");
-      return;
-    }
+    if (!weightSold || !pricePerWeight || !buyerName) {
+    setError("Quantity, price, and customer name are required.");
+    return;
+  }
     setError(null);
     setSaving(true);
     try {
-      const payload: SaleInput = {
-        itemId,
-        weightSold: parseFloat(weightSold),
-        weightUnit: "lb",
-        pricePerWeight: parseFloat(pricePerWeight),
-        totalPrice: parseFloat(totalPrice!),
-        costPerWeight: Number(costPerWeight),
-        soldAt: new Date().toISOString(),
-        notes: notes?.trim() || "",
-      };
+     const payload: SaleInput = {
+      itemId,
+      weightSold: parseFloat(weightSold),
+      weightUnit: "lb",
+      pricePerWeight: parseFloat(pricePerWeight),
+      totalPrice: parseFloat(totalPrice!),
+      costPerWeight: Number(costPerWeight),
+      soldAt: new Date().toISOString(),
+      buyerName,
+      buyerPhone: buyerPhone.trim() || undefined,
+      buyerEmail: buyerEmail.trim() || undefined,
+      buyerAddress: buyerAddress.trim() || undefined,
+      notes: notes?.trim() || "",
+    };
       console.log("SALE PAYLOAD:", payload);
       const result = await addSale(payload);
       onSaleRecorded?.(result.id, result.totalPrice);
@@ -141,14 +149,14 @@ export default function SaleModal({
       <div
         ref={modalRef}
         style={modalStyle}
-        className="relative bg-white rounded-xl shadow-2xl w-[420px] max-w-[95vw] select-none"
+        className="relative bg-white rounded-xl shadow-2xl w-[560px] max-w-[95vw] select-none"
       >
         {/* Draggable header */}
         <div
           className="flex items-center justify-between px-6 pt-6 pb-2 cursor-move"
           onMouseDown={onMouseDown}
         >
-          <h2 className="text-2xl font-bold text-gray-900">Sale Form</h2>
+          <h2 className="text-2xl font-bold text-gray-900">Record a Sale</h2>
           <button
             onClick={onClose}
             className="text-gray-400 hover:text-gray-700 text-xl leading-none p-1 rounded-full hover:bg-gray-100 transition-colors cursor-pointer"
@@ -159,49 +167,86 @@ export default function SaleModal({
         </div>
 
         {/* Body */}
-        <div className="px-6 pb-6 pt-4 flex flex-col gap-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm text-gray-600">
-                Quantity Sold (lbs)
-              </label>
-              <EditableField
-                isEditing
-                value={weightSold}
-                placeholder="Weight"
-                onChange={setWeightSold}
-              />
+        <div className="px-6 pb-6 pt-4 flex flex-col gap-6">
+          {/* Sale Details */}
+          <div className="rounded-xl border border-gray-200 p-4 flex flex-col gap-4">
+            <h3 className="text-base font-semibold text-gray-900">Sale Details</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm text-gray-600">
+                  Quantity Sold (lbs)<span className="text-red-500">*</span>
+                </label>
+                <EditableField
+                  isEditing
+                  value={weightSold}
+                  placeholder="Weight"
+                  onChange={setWeightSold}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm text-gray-600">
+                  Sale Price ($/lb)<span className="text-red-500">*</span>
+                </label>
+                <EditableField
+                  isEditing
+                  value={pricePerWeight}
+                  placeholder="Price"
+                  onChange={setPricePerWeight}
+                />
+              </div>
             </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm text-gray-600">Sale Price ($/lb)</label>
-              <EditableField
-                isEditing
-                value={pricePerWeight}
-                placeholder="Price"
-                onChange={setPricePerWeight}
-              />
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm text-gray-600">Notes</label>
-            <textarea
-              value={notes}
-              placeholder="Notes"
-              onChange={(e) => setNotes(e.target.value)}
-              className="w-full min-h-[80px] resize-y border rounded px-2 py-1 text-sm"
-            />
-          </div>
-
-          {/* Total preview */}
-          {totalPrice && (
-            <div className="rounded-lg bg-gray-50 border border-gray-100 px-4 py-2.5 flex items-center justify-between">
-              <span className="text-sm text-gray-500">Total</span>
+            <div className="flex items-center justify-between border-t border-gray-100 pt-3">
+              <span className="text-sm text-gray-600">Lot Revenue</span>
               <span className="text-sm font-semibold text-gray-900">
-                ${totalPrice}
+                {totalPrice ? `$${totalPrice}` : "—"}
               </span>
             </div>
-          )}
+          </div>
+
+          {/* Customer Information */}
+          <div className="flex flex-col gap-4">
+            <h3 className="text-base font-semibold text-gray-900">Customer Information</h3>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm text-gray-600">
+                  Name<span className="text-red-500">*</span>
+                </label>
+                <EditableField
+                  isEditing
+                  value={buyerName}
+                  placeholder="Full name"
+                  onChange={setBuyerName}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm text-gray-600">Phone Number</label>
+                <EditableField
+                  isEditing
+                  value={buyerPhone}
+                  placeholder="555-000-0000"
+                  onChange={setBuyerPhone}
+                />
+              </div>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm text-gray-600">Email</label>
+              <EditableField
+                isEditing
+                value={buyerEmail}
+                placeholder="email@example.com"
+                onChange={setBuyerEmail}
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm text-gray-600">Address</label>
+              <textarea
+                value={buyerAddress}
+                placeholder="Street, City, State ZIP"
+                onChange={(e) => setBuyerAddress(e.target.value)}
+                className="w-full min-h-[80px] resize-y border rounded px-2 py-1 text-sm"
+              />
+            </div>
+          </div>
 
           {/* Error */}
           {error && <p className="text-sm text-red-500">{error}</p>}
@@ -213,7 +258,7 @@ export default function SaleModal({
               disabled={saving}
               className="rounded-lg bg-[#4a5c2f] hover:bg-[#3a4a24] text-white px-5 py-2 text-sm font-medium disabled:opacity-50 transition-colors cursor-pointer"
             >
-              {saving ? "Recording..." : "Record sale"}
+              {saving ? "Recording..." : "Record Sale"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Added `buyerPhone`, `buyerEmail`, and `buyerAddress` fields to the `SaleFields` backend model and updated the `addSale` controller to validate `buyerName` as required
- Updated `SaleInput` type in the frontend API layer to include `totalPrice`
- Redesigned `Add-Sale.tsx` to match Figma: "Record a Sale" title, Sale Details card with Lot Revenue display, and a Customer Information section (Name, Phone, Email, Address)

## Testing
- [ ] Open the sale modal on an inventory item
- [ ] Verify Lot Revenue auto-calculates as quantity × price
- [ ] Submit with Name blank — should show validation error
- [ ] Submit with all required fields filled — sale should record successfully
- [ ] Verify `buyerPhone`, `buyerEmail`, `buyerAddress` are saved (optional fields)
<img width="1371" height="744" alt="image" src="https://github.com/user-attachments/assets/05f8e67c-c5f8-4da4-a53b-8326abfaa7d1" />
<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/dafbc562-be52-4017-8d0f-e56e935c7a7b" />
